### PR TITLE
Add a Netrack OpenFlow controller framework

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ SONiC
 - [Ravel](https://github.com/ravel-net/ravel) - A software-defined networking (SDN) controller that uses a standard SQL database to represent the network.
 - [Trema](https://trema.github.io/trema/) - A full-stack, easy-to-use framework for developing OpenFlow controllers in Ruby and C.
 - [Open Security Controller](https://www.opensecuritycontroller.org/) - Software-defined security orchestration solution that automates deployment of virtualized network security functions, like next-generation firewall, intrusion prevention systems and application data controllers
+- [Netrack](https://github.com/netrack/openflow) - An OpenFlow controller framework in Go.
 
 # Simulator/Emulator
 


### PR DESCRIPTION
This patch adds a link to Netrack OpenFlow controller framework written in Go to the list of awesome SDN controllers.